### PR TITLE
fix: use crates.io datafusion-federation for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,8 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-federation"
-version = "0.4.7"
-source = "git+https://github.com/GeorgeLeePatterson/datafusion-federation?branch=fix-unnest-with-new-exprs#86fca10685162c6911feada5d453a40e776fcaa5"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c34a9c0dfabcefa3619a3593b23c7f63f14caa7c5e8bfdd82c5948140483cd4"
 dependencies = [
  "arrow-json",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,10 @@ tracing-subscriber = { version = "0.3", features = ["fmt"] }
 # NOTE: There's a current "TODO" to enforce the compatibility fully, but updates seem to lag
 # datafusion-table-providers = { version = "0.6", optional = true }
 
-# TODO: Remove this when upstream PR has been merged
-# ref: [PR #135](https://github.com/datafusion-contrib/datafusion-federation/pull/135)
+# Note: Using crates.io version for publishing compatibility
+# Once PR #135 is merged upstream, we can update this dependency
 [dependencies.datafusion-federation]
-git = "https://github.com/GeorgeLeePatterson/datafusion-federation"
-branch = "fix-unnest-with-new-exprs"
+version = "0.4.7"
 features = ["sql"]
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ let builder = ClickHouseBuilder::new("http://localhost:9000")
 
 When the `federation` feature is enabled (default), clickhouse-datafusion can join `ClickHouse` tables with other `DataFusion` sources:
 
+> **Note**: The current release uses `datafusion-federation` v0.4.7 from crates.io for publishing compatibility. This version has a known issue with `UNNEST` operations due to an upstream DataFusion bug in expression handling. If you need `UNNEST` support in federated queries, please track [PR #135](https://github.com/datafusion-contrib/datafusion-federation/pull/135) for the fix.
+
 ```sql
 -- Join ClickHouse with Parquet files
 SELECT


### PR DESCRIPTION
- Switch from git dependency to crates.io v0.4.7 for publishing compatibility
- Add README note about UNNEST limitation in current federation version
- Update Cargo.lock with new dependency source